### PR TITLE
Separate properties from data

### DIFF
--- a/Category.agda
+++ b/Category.agda
@@ -10,6 +10,40 @@ open import Cubical.Foundations.Isomorphism using (isoToPath)
 open import Cubical.Reflection.RecordEquiv
 open import Cubical.Data.Sigma
 
+open import LevelUtil
+
+record CategoryData o h : Type (ℓ-suc (o ⊔ h)) where
+  field
+    Ob : Type o
+    Hom : ∀ (A B : Ob) → Type h
+
+    id : ∀ {A : Ob} → Hom A A
+    _∘_ : ∀ {A B C : Ob} → Hom B C → Hom A B → Hom A C
+
+private variable
+  o h : Level
+
+record isCategory (𝒞 : CategoryData o h) : Type (o ⊔ h) where
+  open CategoryData 𝒞
+
+  field
+    isSetHom : ∀ {A B : Ob} → isSet (Hom A B)
+
+    identˡ : ∀ {A B : Ob} {f : Hom A B} → id ∘ f ≡ f
+    identʳ : ∀ {A B : Ob} {f : Hom A B} → f ∘ id ≡ f
+    assoc : ∀ {A B C D : Ob} {f : Hom A B} {g : Hom B C} {h : Hom C D} → (h ∘ g) ∘ f ≡ h ∘ (g ∘ f)
+
+record Category⬆ o h : Type (ℓ-suc (o ⊔ h)) where
+  constructor category⬆
+
+  field
+    Data : CategoryData o h
+    is-category : isCategory Data
+
+  open CategoryData Data public
+  open isCategory is-category public
+
+-- TODO: remove
 record Category o h : Type (ℓ-suc (ℓ-max o h)) where
   field
     Ob : Type o

--- a/Functor.agda
+++ b/Functor.agda
@@ -6,8 +6,48 @@ open import Cubical.Foundations.HLevels
 
 open import HLevelUtil
 
+open import LevelUtil
+
 open import Category
 
+private variable
+  o h o′ h′ : Level
+  C D E : CategoryData o h
+  𝒞 𝒟 ℰ : Category o h
+
+record FunctorData (𝒞 : CategoryData o h) (𝒟 : CategoryData o′ h′) : Type (levelOfTerm 𝒞 ⊔ levelOfTerm 𝒟) where
+  private
+    module 𝒞 = CategoryData 𝒞
+    module 𝒟 = CategoryData 𝒟
+
+  field
+    F₀ : 𝒞.Ob → 𝒟.Ob
+    F₁ : ∀ {A B : 𝒞.Ob} → 𝒞.Hom A B → 𝒟.Hom (F₀ A) (F₀ B)
+
+  ₀ = F₀
+  ₁ = F₁
+
+record isFunctor {𝒞 : CategoryData o h} {𝒟 : CategoryData o′ h′} (F : FunctorData 𝒞 𝒟) : Type (o ⊔ h ⊔ h′) where
+  private
+    module 𝒞 = CategoryData 𝒞
+    module 𝒟 = CategoryData 𝒟
+    module F = FunctorData F
+
+  field
+    identity : ∀ {A : 𝒞.Ob} → F.₁ (𝒞.id {A}) ≡ 𝒟.id
+    compose : ∀ {A B C : 𝒞.Ob} {f : 𝒞.Hom A B} {g : 𝒞.Hom B C} → F.₁ (g 𝒞.∘ f) ≡ F.₁ g 𝒟.∘ F.₁ f
+
+record Functor⬆ (𝒞 : CategoryData o h) (𝒟 : CategoryData o′ h′) : Type (levelOfTerm 𝒞 ⊔ levelOfTerm 𝒟) where
+  constructor functor⬆
+
+  field
+    Data : FunctorData 𝒞 𝒟
+    is-functor : isFunctor Data
+
+  open FunctorData Data public
+  open isFunctor is-functor public
+
+-- TODO: remove
 record Functor {o h} (𝒞 : Category o h) {o′ h′} (𝒟 : Category o′ h′) : Type (ℓ-max o (ℓ-max h (ℓ-max o′ h′))) where
   private
     module 𝒞 = Category.Category 𝒞
@@ -22,10 +62,36 @@ record Functor {o h} (𝒞 : Category o h) {o′ h′} (𝒟 : Category o′ h�
   ₀ = F₀
   ₁ = F₁
 
+idFunctorData : ∀ {𝒞 : CategoryData o h} → FunctorData 𝒞 𝒞
+idFunctorData = record { F₀ = λ A → A ; F₁ = λ f → f }
+
+isFunctorIdFunctorData : ∀ {𝒞 : CategoryData o h} → isFunctor (idFunctorData {𝒞 = 𝒞})
+isFunctorIdFunctorData = record { identity = refl ; compose = refl }
+
+idFunctor⬆ : ∀ {𝒞 : CategoryData o h} → Functor⬆ 𝒞 𝒞
+idFunctor⬆ = functor⬆ idFunctorData isFunctorIdFunctorData
+
+-- TODO: remove
 module _ {o h} {𝒞 : Category o h} where
   idFunctor : Functor 𝒞 𝒞
   idFunctor = record { F₀ = λ A → A ; F₁ = λ f → f ; identity = refl ; compose = refl }
 
+_∘FData_ : FunctorData D E → FunctorData C D → FunctorData C E
+_∘FData_ G F = record { F₀ = λ A → G.₀ (F.₀ A) ; F₁ = λ A → G.₁ (F.₁ A) }
+  where
+    module F = FunctorData F
+    module G = FunctorData G
+
+isFunctor-∘F : (G : Functor⬆ D E) (F : Functor⬆ C D) → isFunctor (Functor⬆.Data G ∘FData Functor⬆.Data F)
+isFunctor-∘F G F = record { identity = cong G.₁ F.identity ∙ G.identity ; compose = cong G.₁ F.compose ∙ G.compose }
+  where
+    module F = Functor⬆ F
+    module G = Functor⬆ G
+
+_∘F⬆_ : Functor⬆ D E → Functor⬆ C D → Functor⬆ C E
+G ∘F⬆ F = functor⬆ (Functor⬆.Data G ∘FData Functor⬆.Data F) (isFunctor-∘F G F)
+
+-- TODO: remove
 module _ {o h o′ h′ o″ h″} {𝒞 : Category o h} {𝒟 : Category o′ h′} {ℰ : Category o″ h″} where
   _∘F_ : Functor 𝒟 ℰ → Functor 𝒞 𝒟 → Functor 𝒞 ℰ
   G ∘F F = record
@@ -121,11 +187,6 @@ module _ {o h} (𝒞 : Category o h) {o′ h′} (𝒟 : Category o′ h′) whe
       compose : ∀ {A B C} {f : 𝒞 [ A , B ]} {g : 𝒞 [ B , C ]}
         → PathP (λ i → PathP (λ j → Path (𝒟 [ r i j A , r i j C ]) (F₁ (𝒞 [ g ∘ f ]) i j) (𝒟 [ F₁ g i j ∘ F₁ f i j ])) F.compose G.compose) (λ k → Functor.compose (p k)) (λ k → Functor.compose (q k))
       compose = helper′ F.compose G.compose (λ k → Functor.compose (p k)) (λ k → Functor.compose (q k)) r λ i j f → F₁ f i j
-
-private
-  variable
-    o h : Level
-    𝒞 𝒟 : Category o h
 
 isFaithful : (F : Functor 𝒞 𝒟) → Type _
 isFaithful {𝒞 = 𝒞} F = ∀ {A B} (f g : 𝒞.Hom A B) → F.₁ f ≡ F.₁ g → f ≡ g

--- a/NaturalTransformation.agda
+++ b/NaturalTransformation.agda
@@ -11,11 +11,62 @@ open import Cubical.Reflection.RecordEquiv
 open import Category
 open import Functor
 
+open import LevelUtil
+
+private variable
+  o h o′ h′ : Level
+
+module _ {C : CategoryData o h} {D : CategoryData o′ h′} where
+  private
+    module C = CategoryData C
+    module D = CategoryData D
+
+  record NaturalTransformationData (F G : FunctorData C D) : Type (o ⊔ h′) where
+    private
+      module F = FunctorData F
+      module G = FunctorData G
+
+    field
+      component : ∀ (A : C.Ob) → D.Hom (F.₀ A) (G.₀ A)
+
+  record isNaturalTransformation {F G : FunctorData C D} (α : NaturalTransformationData F G) : Type (o ⊔ h ⊔ h′) where
+    private
+      module F = FunctorData F
+      module G = FunctorData G
+      module α = NaturalTransformationData α
+
+    field
+      commute : ∀ (A B : C.Ob) {f : C.Hom A B} → α.component B D.∘ F.₁ f ≡ G.₁ f D.∘ α.component A
+
+  record NaturalTransformation⬆ (F G : FunctorData C D) : Type (o ⊔ h ⊔ h′) where
+    constructor naturalTransformation⬆
+
+    field
+      Data : NaturalTransformationData F G
+      is-natural-transformation : isNaturalTransformation Data
+
+    open NaturalTransformationData Data public
+    open isNaturalTransformation is-natural-transformation public
+
+private variable
+  C D : CategoryData o h
+
+idNatTransData : {F : FunctorData C D} → NaturalTransformationData F F
+idNatTransData {D = D} = record { component = λ A → CategoryData.id D }
+
+isNaturalTransformationIdNatTransData : isCategory D → {F : FunctorData C D} → isNaturalTransformation (idNatTransData {F = F})
+isNaturalTransformationIdNatTransData isCat = record { commute = λ A B → isCat.identˡ ∙ sym isCat.identʳ }
+  where module isCat = isCategory isCat
+
+idNatTrans⬆ : isCategory D → {F : FunctorData C D} → NaturalTransformation⬆ F F
+idNatTrans⬆ isCat = naturalTransformation⬆ idNatTransData (isNaturalTransformationIdNatTransData isCat)
+
 module _ {o h} {𝒞 : Category o h} {o′ h′} {𝒟 : Category o′ h′} where
   private
     module 𝒞 = Category.Category 𝒞
     module 𝒟 = Category.Category 𝒟
 
+  -- TODO: remove
   record NaturalTransformation (F G : Functor 𝒞 𝒟) : Type (ℓ-max o (ℓ-max h h′)) where
     private
       module F = Functor.Functor F
@@ -49,6 +100,7 @@ module _ {o h} {𝒞 : Category o h} {o′ h′} {𝒟 : Category o′ h′} whe
         a : ∀ {A B f} → PathP (λ i → 𝒟 [ p i B ∘ F.₁ f ] ≡ 𝒟 [ G.₁ f ∘ p i A ]) (α.commute A B {f}) (β.commute A B {f})
         a {A} {B} {f} = toPathP (𝒟.isSetHom _ _ _ _)
 
+  -- TODO: remove
   idNatTrans : ∀ {F : Functor 𝒞 𝒟} → NaturalTransformation F F
   idNatTrans {F} = record { component = λ A → 𝒟.id ; commute = λ A B {f} → 𝒟.identˡ ∙ sym 𝒟.identʳ }
 


### PR DESCRIPTION
Confining data and properties to a single record and defining operations on the entire record require tedious transporting along unique paths.

## Plan

- [ ] For each record type, say `Category`, create 3 record types `CategoryData`, `isCategory`, and `Category⬆`. I've arbitrarily chosen the symbol `⬆`, which is unlikely to be used for other purposes.
- [ ] Remove old record types, in the above case `Category`, and rename `Category⬆` to `Category`.